### PR TITLE
Upgrading Vertx and Vertx Util Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
 
   <properties>
     <!--Vertx dependency versions-->
-    <vertx.version>3.4.1</vertx.version>
-    <vertx.utils.version>3.0.1</vertx.utils.version>
+    <vertx.version>3.5.4</vertx.version>
+    <vertx.utils.version>3.4.1</vertx.utils.version>
 
     <!--Other dependency versions-->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
For Enabling SMA Metrics in deckard, we have updated vertx libraries in Deckard but Metrics library used in this Repo  was outdated and was givving runtime error To fix that we need a new release of this repo with upgraded versions of vertx and vertx-utils